### PR TITLE
[PR for PR] get rid of intermediate interface, fix `getOwnPropertyDescriptor`, better documentation

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -203,17 +203,13 @@ export interface DetachedField extends Opaque<Brand<string, "tree.DetachedField"
 const DUMMY_INVERT_TAG: ChangesetTag;
 
 // @public
-export interface EditableField extends EditableFieldMethods, ArrayLike<UnwrappedEditableTree> {
+export interface EditableField extends ArrayLike<UnwrappedEditableTree> {
     readonly [proxyTargetSymbol]: object;
     [Symbol.iterator](): IterableIterator<UnwrappedEditableTree>;
     readonly fieldKey: FieldKey;
     readonly fieldSchema: FieldSchema;
-    readonly primaryType?: TreeSchemaIdentifier;
-}
-
-// @public
-export interface EditableFieldMethods {
     getWithoutUnwrapping(index: number): EditableTree;
+    readonly primaryType?: TreeSchemaIdentifier;
 }
 
 // @public

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -9,7 +9,6 @@ export {
     getTypeSymbol,
     EditableTree,
     EditableField,
-    EditableFieldMethods,
     EditableTreeOrPrimitive,
     isEditableField,
     isUnwrappedNode,

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -15,7 +15,6 @@ export {
 export {
     anchorSymbol,
     EditableField,
-    EditableFieldMethods,
     EditableTree,
     EditableTreeContext,
     EditableTreeOrPrimitive,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -136,7 +136,6 @@ export {
     EditableTreeOrPrimitive,
     EditableTree,
     EditableField,
-    EditableFieldMethods,
     isPrimitiveValue,
     isPrimitive,
     getTypeSymbol,


### PR DESCRIPTION
An alternative to `EditableFieldMethods` in https://github.com/microsoft/FluidFramework/pull/12621