### PR TITLE
Tree: EditableTree refactoring

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -416,6 +416,12 @@ export interface GenericTreeNode<TChild> extends GenericFieldsNode<TChild>, Node
 export const getField: unique symbol;
 
 // @public
+export function getPrimaryField(schema: TreeSchema): {
+    key: LocalFieldKey;
+    schema: FieldSchema;
+} | undefined;
+
+// @public
 export type GlobalFieldKey = Brand<string, "tree.GlobalFieldKey">;
 
 // @public

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -22,4 +22,4 @@ export {
 
 export { EditableTreeContext, getEditableTreeContext } from "./editableTreeContext";
 
-export { PrimitiveValue, isPrimitiveValue, isPrimitive } from "./utilities";
+export { PrimitiveValue, isPrimitiveValue, isPrimitive, getPrimaryField } from "./utilities";

--- a/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
@@ -65,6 +65,11 @@ export function assertPrimitiveValueType(nodeValue: Value, schema: TreeSchema): 
     }
 }
 
+/**
+ * Returns the key and the schema of the primary field out of the given tree schema.
+ *
+ * See note on {@link EmptyKey} for what is a primary field.
+ */
 export function getPrimaryField(
     schema: TreeSchema,
 ): { key: LocalFieldKey; schema: FieldSchema } | undefined {

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -24,6 +24,7 @@ export {
     isEditableField,
     isPrimitive,
     isPrimitiveValue,
+    getPrimaryField,
     isUnwrappedNode,
     PrimitiveValue,
     proxyTargetSymbol,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -146,6 +146,7 @@ export {
     EditableField,
     isPrimitiveValue,
     isPrimitive,
+    getPrimaryField,
     typeSymbol,
     typeNameSymbol,
     valueSymbol,

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -32,14 +32,7 @@ import {
     valueSymbol,
 } from "../../../feature-libraries";
 import { ITestTreeProvider, TestTreeProvider } from "../../utils";
-import {
-    ComplexPhoneType,
-    fullSchemaData,
-    personData,
-    PersonType,
-    schemaMap,
-    stringSchema,
-} from "./mockData";
+import { fullSchemaData, personData, Person, schemaMap, stringSchema } from "./mockData";
 
 const globalFieldKey: GlobalFieldKey = brand("foo");
 const globalFieldSymbol = symbolFromKey(globalFieldKey);
@@ -90,21 +83,22 @@ const testCases: (readonly [string, FieldKey])[] = [
 describe("editable-tree: editing", () => {
     it("assert set primitive value using assignment", async () => {
         const [, trees] = await createSharedTrees(fullSchemaData, [personData]);
-        const person = trees[0].root as PersonType;
+        const person = trees[0].root as Person;
         const nameNode = person[getField](brand("name")).getNode(0);
         const ageNode = person[getField](brand("age")).getNode(0);
-        const phonesField = person.address.phones;
-        assert(isEditableField(phonesField));
 
         assert.throws(
-            () => (person.friends[valueSymbol] = { kate: "kate" }),
+            () => {
+                assert(person.friends !== undefined);
+                person.friends[valueSymbol] = { kate: "kate" };
+            },
             (e) => validateAssertionError(e, "The value is not primitive"),
             "Expected exception was not thrown",
         );
         assert.throws(
             () => {
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-                phonesField[2] = {} as ComplexPhoneType;
+                assert(person.address !== undefined);
+                person.address[valueSymbol] = 123;
             },
             (e) => validateAssertionError(e, "Cannot set a value of a non-primitive field"),
             "Expected exception was not thrown",

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTreeContext.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTreeContext.spec.ts
@@ -9,9 +9,12 @@ import { createField, isUnwrappedNode, singleTextCursor } from "../../../feature
 import { ISharedTree } from "../../../shared-tree";
 import { brand } from "../../../util";
 import { ITestTreeProvider, TestTreeProvider } from "../../utils";
-// eslint-disable-next-line import/no-internal-modules
+
+// Allow importing from this specific file which is being tested:
+/* eslint-disable-next-line import/no-internal-modules */
 import { ProxyContext } from "../../../feature-libraries/editable-tree/editableTreeContext";
-import { fullSchemaData, int32Schema, personData, PersonType } from "./mockData";
+
+import { fullSchemaData, int32Schema, personData, Person } from "./mockData";
 
 async function createSharedTrees(
     schemaData: SchemaData,
@@ -31,8 +34,8 @@ async function createSharedTrees(
 describe("editable-tree context", () => {
     it("can't synchronize trees after the context been freed", async () => {
         const [provider, [tree1, tree2]] = await createSharedTrees(fullSchemaData, [personData], 2);
-        const person1 = tree1.root as PersonType;
-        const person2 = tree2.root as PersonType;
+        const person1 = tree1.root as Person;
+        const person2 = tree2.root as Person;
         tree2.context.free();
 
         assert.equal(person1.age, 35);
@@ -46,12 +49,12 @@ describe("editable-tree context", () => {
     it("can clear and reuse context", async () => {
         const [provider, [tree1, tree2]] = await createSharedTrees(fullSchemaData, [personData], 2);
         const context2 = tree2.context;
-        const person1 = tree1.root as PersonType;
+        const person1 = tree1.root as Person;
 
-        let person2 = tree2.root as PersonType;
+        let person2 = tree2.root as Person;
         context2.attachAfterChangeHandler((context) => {
             context.clear();
-            person2 = context.unwrappedRoot as PersonType;
+            person2 = context.unwrappedRoot as Person;
         });
 
         // reify EditableTrees

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+// Allow defining a custom "String" type:
+/* eslint-disable @typescript-eslint/ban-types */
+
 import { emptyField, FieldKinds, EditableTree, EditableField } from "../../../feature-libraries";
 import {
     namedTreeSchema,
@@ -37,10 +40,24 @@ export const int32Schema = namedTreeSchema({
     value: ValueSchema.Number,
 });
 
-export const float32Schema = namedTreeSchema({
-    name: brand("Float32"),
+export const float64Schema = namedTreeSchema({
+    name: brand("Float64"),
     extraLocalFields: emptyField,
     value: ValueSchema.Number,
+});
+
+export const boolSchema = namedTreeSchema({
+    name: brand("Bool"),
+    extraLocalFields: emptyField,
+    value: ValueSchema.Boolean,
+});
+
+export const simplePhonesSchema = namedTreeSchema({
+    name: brand("Test:SimplePhones-1.0.0"),
+    localFields: {
+        [EmptyKey]: fieldSchema(FieldKinds.sequence, [stringSchema.name]),
+    },
+    extraLocalFields: emptyField,
 });
 
 export const complexPhoneSchema = namedTreeSchema({
@@ -48,14 +65,7 @@ export const complexPhoneSchema = namedTreeSchema({
     localFields: {
         number: fieldSchema(FieldKinds.value, [stringSchema.name]),
         prefix: fieldSchema(FieldKinds.value, [stringSchema.name]),
-    },
-    extraLocalFields: emptyField,
-});
-
-export const simplePhonesSchema = namedTreeSchema({
-    name: brand("Test:SimplePhones-1.0.0"),
-    localFields: {
-        [EmptyKey]: fieldSchema(FieldKinds.sequence, [stringSchema.name]),
+        extraPhones: fieldSchema(FieldKinds.optional, [simplePhonesSchema.name]),
     },
     extraLocalFields: emptyField,
 });
@@ -85,8 +95,10 @@ export const globalFieldSchemaSequencePhones = fieldSchema(FieldKinds.sequence, 
 export const addressSchema = namedTreeSchema({
     name: brand("Test:Address-1.0.0"),
     localFields: {
-        street: fieldSchema(FieldKinds.value, [stringSchema.name]),
-        zip: fieldSchema(FieldKinds.optional, [stringSchema.name, int32Schema.name]),
+        zip: fieldSchema(FieldKinds.value, [stringSchema.name, int32Schema.name]),
+        street: fieldSchema(FieldKinds.optional, [stringSchema.name]),
+        city: fieldSchema(FieldKinds.optional, [stringSchema.name]),
+        country: fieldSchema(FieldKinds.optional, [stringSchema.name]),
         phones: fieldSchema(FieldKinds.optional, [phonesSchema.name]),
         sequencePhones: fieldSchema(FieldKinds.sequence, [stringSchema.name]),
     },
@@ -106,9 +118,10 @@ export const personSchema = namedTreeSchema({
     localFields: {
         name: fieldSchema(FieldKinds.value, [stringSchema.name]),
         age: fieldSchema(FieldKinds.optional, [int32Schema.name]),
-        salary: fieldSchema(FieldKinds.value, [float32Schema.name]),
+        adult: fieldSchema(FieldKinds.optional, [boolSchema.name]),
+        salary: fieldSchema(FieldKinds.optional, [float64Schema.name, int32Schema.name]),
         friends: fieldSchema(FieldKinds.optional, [mapStringSchema.name]),
-        address: fieldSchema(FieldKinds.value, [addressSchema.name]),
+        address: fieldSchema(FieldKinds.optional, [addressSchema.name]),
     },
     extraLocalFields: emptyField,
 });
@@ -136,8 +149,9 @@ export const schemaTypes: Set<NamedTreeSchema> = new Set([
     arraySchema,
     optionalChildSchema,
     stringSchema,
-    float32Schema,
+    float64Schema,
     int32Schema,
+    boolSchema,
     complexPhoneSchema,
     phonesSchema,
     simplePhonesSchema,
@@ -163,40 +177,62 @@ export const fullSchemaData: SchemaData = {
 
 // TODO: derive types like these from those schema, which subset EditableTree
 
-export type Int32 = Brand<number, "Int32">;
+export type Float64 = Brand<number, "editable-tree.Float64"> & EditableTree;
+export type Int32 = Brand<number, "editable-tree.Int32"> & EditableTree;
+export type String = Brand<string, "editable-tree.String"> & EditableTree;
+export type Bool = Brand<boolean, "editable-tree.Bool"> & EditableTree;
 
-export type ComplexPhoneType = EditableTree & {
-    number: string;
-    prefix: string;
-};
+export type ComplexPhone = EditableTree &
+    Brand<
+        {
+            number: String;
+            prefix: String;
+            extraPhones?: SimplePhones;
+        },
+        "editable-tree.Test:Phone-1.0.0"
+    >;
 
-export type SimplePhonesType = EditableField & string[];
+export type SimplePhones = EditableField & Brand<String[], "editable-tree.Test:SimplePhones-1.0.0">;
 
-export type PhonesType = EditableField & (number | string | ComplexPhoneType | SimplePhonesType)[];
+export type Phones = EditableField &
+    Brand<(Int32 | String | ComplexPhone | SimplePhones)[], "editable-tree.Test:Phones-1.0.0">;
 
-export type AddressType = EditableTree & {
-    street: string;
-    zip?: string;
-    phones?: PhonesType;
-    sequencePhones?: SimplePhonesType;
-};
+export type Address = EditableTree &
+    Brand<
+        {
+            zip: String | Int32;
+            street?: String;
+            city?: String;
+            country?: String;
+            phones?: Phones;
+            sequencePhones?: SimplePhones;
+        },
+        "editable-tree.Test:Address-1.0.0"
+    >;
 
-export type FriendsType = EditableTree & Record<LocalFieldKey, string>;
+export type Friends = EditableTree &
+    Brand<Record<LocalFieldKey, String>, "editable-tree.Map<String>">;
 
-export type PersonType = EditableTree & {
-    name: string;
-    age?: Int32;
-    salary: number;
-    friends: FriendsType;
-    address: AddressType;
-};
+export type Person = EditableTree &
+    Brand<
+        {
+            name: String;
+            age?: Int32;
+            adult?: Bool;
+            salary?: Float64 | Int32;
+            friends?: Friends;
+            address?: Address;
+        },
+        "editable-tree.Test:Person-1.0.0"
+    >;
 
 export const personData: JsonableTree = {
     type: personSchema.name,
     fields: {
         name: [{ value: "Adam", type: stringSchema.name }],
         age: [{ value: 35, type: int32Schema.name }],
-        salary: [{ value: 10420.2, type: float32Schema.name }],
+        adult: [{ value: true, type: boolSchema.name }],
+        salary: [{ value: 10420.2, type: float64Schema.name }],
         friends: [
             {
                 fields: {

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
@@ -3,9 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// Allow defining a custom "String" type:
-/* eslint-disable @typescript-eslint/ban-types */
-
 import { emptyField, FieldKinds, EditableTree, EditableField } from "../../../feature-libraries";
 import {
     namedTreeSchema,
@@ -179,31 +176,30 @@ export const fullSchemaData: SchemaData = {
 
 export type Float64 = Brand<number, "editable-tree.Float64"> & EditableTree;
 export type Int32 = Brand<number, "editable-tree.Int32"> & EditableTree;
-export type String = Brand<string, "editable-tree.String"> & EditableTree;
 export type Bool = Brand<boolean, "editable-tree.Bool"> & EditableTree;
 
 export type ComplexPhone = EditableTree &
     Brand<
         {
-            number: String;
-            prefix: String;
+            number: string;
+            prefix: string;
             extraPhones?: SimplePhones;
         },
         "editable-tree.Test:Phone-1.0.0"
     >;
 
-export type SimplePhones = EditableField & Brand<String[], "editable-tree.Test:SimplePhones-1.0.0">;
+export type SimplePhones = EditableField & Brand<string[], "editable-tree.Test:SimplePhones-1.0.0">;
 
 export type Phones = EditableField &
-    Brand<(Int32 | String | ComplexPhone | SimplePhones)[], "editable-tree.Test:Phones-1.0.0">;
+    Brand<(Int32 | string | ComplexPhone | SimplePhones)[], "editable-tree.Test:Phones-1.0.0">;
 
 export type Address = EditableTree &
     Brand<
         {
-            zip: String | Int32;
-            street?: String;
-            city?: String;
-            country?: String;
+            zip: string | Int32;
+            street?: string;
+            city?: string;
+            country?: string;
             phones?: Phones;
             sequencePhones?: SimplePhones;
         },
@@ -211,12 +207,12 @@ export type Address = EditableTree &
     >;
 
 export type Friends = EditableTree &
-    Brand<Record<LocalFieldKey, String>, "editable-tree.Map<String>">;
+    Brand<Record<LocalFieldKey, string>, "editable-tree.Map<String>">;
 
 export type Person = EditableTree &
     Brand<
         {
-            name: String;
+            name: string;
             age?: Int32;
             adult?: Bool;
             salary?: Float64 | Int32;


### PR DESCRIPTION
This PR refactors the EditableTree and its tests. It is based on top of [#12902](https://github.com/microsoft/FluidFramework/pull/12902).

The main cause of this is to prepare the code base for the upcoming implementation of "simple assignments" and hence to make the latter smaller i.e. better for a review.

Main changes in the productive code:
- `getPrimaryField` is exposed to let users handle corresponding cases (e.g. arrays)
- `getFieldSchema` is wrapped within the EditableTree proxy - this has no use currently, but will be needed in "simple assignments"

Changes in tests are mainly caused by improving the mock data. Those improvements are the result of the "Property Inspector" PoC demoed for various user groups, introducing among others the type `Bool` and a schema (and type) for the "array of array" usecase.