### PR TITLE
initial work toward cleaner field assignment

### DIFF
--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -29,7 +29,7 @@ import { DefaultChangeset, DefaultEditBuilder } from "../defaultChangeFamily";
 import { runSynchronousTransaction } from "../defaultTransaction";
 import { singleMapTreeCursor } from "../mapTreeCursor";
 import { ProxyTarget, EditableField, proxifyField, UnwrappedEditableField } from "./editableTree";
-import { applyFieldTypesFromContext, ContextuallyTypedNodeData } from "./utilities";
+import { applyFieldTypesFromContext, ContextuallyTypedNodeData, isArrayLike } from "./utilities";
 
 /**
  * A common context of a "forest" of EditableTrees.
@@ -154,33 +154,24 @@ export class ProxyContext implements EditableTreeContext {
         return this.getRoot(true);
     }
 
-    // TODO: remove or fix this.
-    // public set unwrappedRoot(value: ContextuallyTypedNodeData) {
-    //     const rootField = this.getRoot(false);
-    //     const mapTrees = applyFieldTypesFromContext(this.schema, rootField.fieldSchema, value);
-    //     const cursors = mapTrees.map(singleMapTreeCursor);
-    //     if (rootField.length > 0) {
-    //         rootField.replaceNodes(0, cursors);
-    //     } else {
-    //         rootField.insertNodes(0, cursors);
-    //     }
-    // }
-
-    public get root(): EditableField {
-        return this.getRoot(false);
-    }
-
-    public set root(value: ContextuallyTypedNodeData | EditableField) {
+    public set unwrappedRoot(value: ContextuallyTypedNodeData | undefined) {
         const rootField = this.getRoot(false);
-        assert(Array.isArray(value), "expected array data");
         const mapTrees = applyFieldTypesFromContext(this.schema, rootField.fieldSchema, value);
         const cursors = mapTrees.map(singleMapTreeCursor);
-
         if (rootField.length > 0) {
             rootField.replaceNodes(0, cursors);
         } else {
             rootField.insertNodes(0, cursors);
         }
+    }
+
+    public get root(): EditableField {
+        return this.getRoot(false);
+    }
+
+    public set root(value: ContextuallyTypedNodeData | undefined) {
+        assert(isArrayLike(value), "expected array data");
+        this.unwrappedRoot = value;
     }
 
     private getRoot(unwrap: false): EditableField;

--- a/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
@@ -20,15 +20,17 @@ import {
     TreeSchemaIdentifier,
     lookupTreeSchema,
     TreeValue,
+    GlobalFieldKeySymbol,
+    TreeTypeSet,
     MapTree,
-    ITreeCursor,
+    symbolIsFieldKey,
 } from "../../core";
 // TODO:
 // This module currently is assuming use of defaultFieldKinds.
 // The field kinds should instead come from a view schema registry thats provided somewhere.
 import { fieldKinds } from "../defaultFieldKinds";
 import { FieldKind, Multiplicity } from "../modular-schema";
-import { singleMapTreeCursor } from "../mapTreeCursor";
+import { typeNameSymbol, valueSymbol } from "./editableTree";
 
 /**
  * @returns true iff `schema` trees should default to being viewed as just their value when possible.
@@ -54,21 +56,44 @@ export function isPrimitiveValue(nodeValue: Value): nodeValue is PrimitiveValue 
     return nodeValue !== undefined && typeof nodeValue !== "object";
 }
 
-export function assertPrimitiveValueType(nodeValue: Value, schema: TreeSchema): void {
-    assert(isPrimitiveValue(nodeValue), 0x45b /* The value is not primitive */);
+export function allowsValue(schema: ValueSchema, nodeValue: Value): boolean {
+    switch (schema) {
+        case ValueSchema.String:
+            return typeof nodeValue === "string";
+        case ValueSchema.Number:
+            return typeof nodeValue === "number";
+        case ValueSchema.Boolean:
+            return typeof nodeValue === "boolean";
+        case ValueSchema.Nothing:
+            return typeof nodeValue === undefined;
+        case ValueSchema.Serializable:
+            return true;
+        default:
+            fail("invalid value schema");
+    }
+}
+
+export function allowsPrimitiveValueType(nodeValue: Value, schema: TreeSchema): boolean {
+    if (!isPrimitiveValue(nodeValue)) {
+        return false;
+    }
     switch (schema.value) {
         case ValueSchema.String:
-            assert(typeof nodeValue === "string", 0x45c /* Expected string */);
-            break;
+            return typeof nodeValue === "string";
         case ValueSchema.Number:
-            assert(typeof nodeValue === "number", 0x45d /* Expected number */);
-            break;
+            return typeof nodeValue === "number";
         case ValueSchema.Boolean:
-            assert(typeof nodeValue === "boolean", 0x45e /* Expected boolean */);
-            break;
+            return typeof nodeValue === "boolean";
         default:
-            fail("wrong value schema");
+            fail("invalid value schema");
     }
+}
+
+export function assertPrimitiveValueType(nodeValue: Value, schema: TreeSchema): void {
+    assert(
+        allowsPrimitiveValueType(nodeValue, schema),
+        "unsupported schema for provided primitive",
+    );
 }
 
 /**
@@ -111,14 +136,14 @@ export function getFieldKind(fieldSchema: FieldSchema): FieldKind {
 }
 
 /**
- * Asserts that the field is not polymorphic i.e. mono-typed and returns this single type.
+ * @returns all allowed child types for `typeSet`.
  */
-export function tryGetNodeType(fieldSchema: FieldSchema): TreeSchemaIdentifier {
-    if (fieldSchema.types === undefined) debugger;
-    const types = fieldSchema.types ?? fail("missing field types");
-    assert(types.size === 1, "cannot resolve the type");
-    const type = [...types][0];
-    return type;
+export function getAllowedTypes(
+    schema: SchemaDataAndPolicy,
+    typeSet: TreeTypeSet,
+): ReadonlySet<TreeSchemaIdentifier> {
+    // TODO: Performance: avoid the `undefined` case being frequent, possibly with caching in the caller of `getPossibleChildTypes`.
+    return typeSet ?? new Set(schema.treeSchema.keys());
 }
 
 /**
@@ -161,97 +186,133 @@ export function keyIsValidIndex(key: string | number, length: number): boolean {
 }
 
 /**
- * Attempts to wrap an arbitrary data into a cursor, trying to resolve data types according to the given schema.
+ * Content of a tree which needs external schema information to interpret.
  *
- * Note that the name of this function as well as its return type do not specify the tree format on purpose
- * to encourage a development of support for pluggable formats/cursors in the EditableTree API.
+ * This format is intended for concise authoring of tree literals when the schema is statically known.
+ *
+ * Once schema aware APIs are implemented, they can be used to provide schema specific subsets of this type.
  */
-export function tryGetCursorFor(
-    schema: SchemaDataAndPolicy,
-    fieldSchema: FieldSchema,
-    data: unknown,
-): ITreeCursor {
-    const node = DetachedNode.create(schema, fieldSchema, data);
-    return singleMapTreeCursor(node);
+export type ContextuallyTypedNodeData =
+    | ContextuallyTypedNodeDataObject
+    | PrimitiveValue
+    // TODO: this should be made compatible with EditableField (use ArrayLike), but that would break Array.isArray checking.
+    | ContextuallyTypedNodeData[];
+
+/**
+ * Object case of {@link ContextuallyTypedNodeData}.
+ */
+export interface ContextuallyTypedNodeDataObject {
+    readonly [valueSymbol]?: TreeValue;
+    readonly [typeNameSymbol]?: TreeSchemaIdentifier;
+    readonly [key: string | GlobalFieldKeySymbol]: ContextuallyTypedNodeData;
 }
 
 /**
- * This implementation of the MapTree is written to wrap an arbitrary data with respect to the tree schema.
+ * @returns false if `data` is incompatible compatible with `type` based on a cheap/shallow check.
  *
- * It is used as an intermediate storage for the user data,
- * whenever a user utilizes simple assignments to change an EditableTree,
- * as methods of the EditableTree accept only cursors as an input data.
+ * Note that this may return true for cases where data is incompatible, but it must not return false in cases where the data is compatible.
  */
-export class DetachedNode implements MapTree {
-    public readonly value?: TreeValue;
-    private readonly data?: object;
+function shallowCompatibilityTest(
+    schemaData: SchemaDataAndPolicy,
+    type: TreeSchemaIdentifier,
+    data: ContextuallyTypedNodeData,
+): boolean {
+    const schema = lookupTreeSchema(schemaData, type);
+    if (isPrimitiveValue(data)) {
+        return allowsPrimitiveValueType(data, schema);
+    }
+    if (Array.isArray(data)) {
+        const primary = getPrimaryField(schema);
+        return (
+            primary !== undefined &&
+            getFieldKind(primary.schema).multiplicity === Multiplicity.Sequence
+        );
+    }
+    if (data[typeNameSymbol] !== undefined) {
+        return data[typeNameSymbol] === type;
+    }
+    // For now, consider all not explicitly typed objects shallow compatible.
+    // This will require explicit differentiation in polymorphic cases rather than automatic structural differentiation.
+    return true;
+}
 
-    constructor(
-        public readonly schema: SchemaDataAndPolicy,
-        public readonly type: TreeSchemaIdentifier,
-        data: unknown,
-    ) {
-        if (isPrimitiveValue(data)) {
-            assertPrimitiveValueType(data, lookupTreeSchema(this.schema, this.type));
-            this.value = data;
-        } else {
-            assert(typeof data === "object" && data !== null, "Data should not be null.");
-            this.data = data;
+/**
+ * Construct a MapTree from ContextuallyTypedNodeData.
+ *
+ * TODO: this should probably be refactors into a `try` function which either returns a MapTree or a SchemaError with a path to the error.
+ */
+export function applyTypesFromContext(
+    schemaData: SchemaDataAndPolicy,
+    typeSet: TreeTypeSet,
+    data: ContextuallyTypedNodeData,
+): MapTree {
+    // All types allowed by schema
+    const allowedTypes = getAllowedTypes(schemaData, typeSet);
+
+    const possibleTypes: TreeSchemaIdentifier[] = [];
+    for (const allowed of allowedTypes) {
+        if (shallowCompatibilityTest(schemaData, allowed, data)) {
+            possibleTypes.push(allowed);
         }
     }
 
-    /**
-     * Gets the fields of this node.
-     */
-    get fields(): Map<FieldKey, DetachedNode[]> {
-        const fields: Map<FieldKey, DetachedNode[]> = new Map();
-        if (this.data === undefined) return fields;
-        const nodeSchema = lookupTreeSchema(this.schema, this.type);
-        const primary = getPrimaryField(nodeSchema);
-        if (Array.isArray(this.data) || primary !== undefined) {
-            assert(primary !== undefined, "expected primary field");
-            fields.set(primary.key, this.createField(primary.schema, this.data));
-        } else {
-            for (const propertyKey of Reflect.ownKeys(this.data)) {
-                const childFieldKey: FieldKey = brand(propertyKey);
-                const childValue = Reflect.get(this.data, propertyKey);
-                const fieldSchema = getFieldSchema(childFieldKey, this.schema, nodeSchema);
-                fields.set(childFieldKey, this.createField(fieldSchema, childValue));
-            }
-        }
-        return fields;
+    assert(possibleTypes.length !== 0, "data incompatible with all types allowed by schema");
+    assert(possibleTypes.length === 1, "data compatible with more than one type allowed by schema");
+
+    const type = possibleTypes[0];
+    const schema = lookupTreeSchema(schemaData, type);
+    if (isPrimitiveValue(data)) {
+        assertPrimitiveValueType(data, schema);
+        return { value: data, type, fields: new Map() };
+    }
+    if (Array.isArray(data)) {
+        const primary = getPrimaryField(schema);
+        assert(
+            primary !== undefined,
+            "array data reported comparable with schema without primary field",
+        );
+        const children = applyFieldTypesFromContext(schemaData, primary.schema, data);
+        return { value: data, type, fields: new Map([[primary.key, children]]) };
     }
 
-    /**
-     * Creates the field of this node.
-     */
-    private createField(fieldSchema: FieldSchema, data: unknown): DetachedNode[] {
-        const fieldKind = getFieldKind(fieldSchema);
-        if (fieldKind.multiplicity === Multiplicity.Sequence) {
-            assert(Array.isArray(data), "expected array");
-            return data.map((v) => DetachedNode.create(this.schema, fieldSchema, v));
-        } else {
-            return [DetachedNode.create(this.schema, fieldSchema, data)];
-        }
-    }
+    const fields: Map<FieldKey, MapTree[]> = new Map(
+        Object.keys(data)
+            .filter((key) => typeof key === "string" || symbolIsFieldKey(key))
+            .map((key) => [
+                brand(key),
+                applyFieldTypesFromContext(
+                    schemaData,
+                    getFieldSchema(brand(key), schemaData, schema),
+                    data,
+                ),
+            ]),
+    );
 
-    /**
-     * A helper function to create new nodes in cases, when the node type is unknown upfront.
-     */
-    static create(
-        schema: SchemaDataAndPolicy,
-        fieldSchema: FieldSchema,
-        data: unknown,
-    ): DetachedNode {
-        if (data instanceof DetachedNode) {
-            if (fieldSchema.types !== undefined) {
-                assert(
-                    fieldSchema.types.has(data.type),
-                    "The data type does not match the field schema.",
-                );
-            }
-            return data;
-        }
-        return new DetachedNode(schema, tryGetNodeType(fieldSchema), data);
+    const value = data[valueSymbol];
+    assert(allowsValue(schema.value, value), "provided value not permitted by schema");
+
+    return { value, type, fields };
+}
+
+/**
+ * Construct a MapTree from ContextuallyTypedNodeData.
+ *
+ * TODO: this should probably be refactors into a `try` function which either returns a MapTree or a SchemaError with a path to the error.
+ */
+export function applyFieldTypesFromContext(
+    schemaData: SchemaDataAndPolicy,
+    field: FieldSchema,
+    data: ContextuallyTypedNodeData,
+): MapTree[] {
+    const multiplicity = getFieldKind(field).multiplicity;
+    if (Array.isArray(data)) {
+        assert(multiplicity === Multiplicity.Sequence, "got array for non sequence field");
+        const children = data.map((child) => applyTypesFromContext(schemaData, field.types, child));
+        return children;
     }
+    assert(
+        multiplicity === Multiplicity.Value || multiplicity === Multiplicity.Optional,
+        "Single value provided for unsupported field",
+    );
+    return [applyTypesFromContext(schemaData, field.types, data)];
 }

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -44,14 +44,12 @@ import {
     Float64,
     Int32,
     int32Schema,
-    Phones,
     SimplePhones,
     simplePhonesSchema,
     getPerson,
     globalFieldSymbolSequencePhones,
     Address,
 } from "./mockData";
-import { ContextuallyTypedNodeData } from "../../../feature-libraries/editable-tree/utilities";
 
 const globalFieldKey: GlobalFieldKey = brand("foo");
 const globalFieldSymbol = symbolFromKey(globalFieldKey);

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -49,7 +49,9 @@ import {
     simplePhonesSchema,
     getPerson,
     globalFieldSymbolSequencePhones,
+    Address,
 } from "./mockData";
+import { ContextuallyTypedNodeData } from "../../../feature-libraries/editable-tree/utilities";
 
 const globalFieldKey: GlobalFieldKey = brand("foo");
 const globalFieldSymbol = symbolFromKey(globalFieldKey);
@@ -150,13 +152,12 @@ describe("editable-tree: editing", () => {
             // create optional field
             person.age = brand(32);
 
-            const phones: Phones = brand([context.newDetachedNode(int32Schema.name, 12345)]);
             // replace optional field
-            person.address = brand({
-                zip: context.newDetachedNode(stringSchema.name, "99999"),
+            person.address = {
+                zip: "99999",
                 street: "foo",
-                phones,
-            });
+                phones: 12345,
+            } as unknown as Address; // TODO: either fix up these strong types to reflect unwrapping, or use untyped API to remove these `as` casts.
             assert(person.address !== undefined);
 
             // create sequence field


### PR DESCRIPTION
## Description

This PR is progress toward allowing tree edits which look like:

```typescript
person.address = {
                zip: "99999",
                street: "foo",
                phones: 12345,
            }; 
```

It does this by introducing a new type: `ContextuallyTypedNodeData` which is less constrained type than UnwrapedEditiableTree.

