### PR TITLE
[PoC] inspector for EditableTree with transaction handling

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -242,6 +242,8 @@ export interface EditableTree extends Iterable<EditableField>, ContextuallyTyped
 
 // @public
 export interface EditableTreeContext {
+    // (undocumented)
+    abortTransaction(): void;
     attachAfterChangeHandler(afterChangeHandler: (context: EditableTreeContext) => void): void;
     clear(): void;
     // (undocumented)

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -217,6 +217,7 @@ export interface DetachedField extends Opaque<Brand<string, "tree.DetachedField"
 // @public
 export interface EditableField extends MarkedArrayLike<UnwrappedEditableTree | ContextuallyTypedNodeData> {
     readonly [proxyTargetSymbol]: object;
+    readonly context: EditableTreeContext;
     deleteNodes(index: number, count?: number): void;
     readonly fieldKey: FieldKey;
     readonly fieldSchema: FieldSchema;
@@ -229,6 +230,7 @@ export interface EditableField extends MarkedArrayLike<UnwrappedEditableTree | C
 // @public
 export interface EditableTree extends Iterable<EditableField>, ContextuallyTypedNodeDataObject {
     [createField](fieldKey: FieldKey, newContent: ITreeCursor | ITreeCursor[]): void;
+    readonly [editableTreeContextSymbol]: EditableTreeContext;
     [getField](fieldKey: FieldKey): EditableField;
     readonly [indexSymbol]: number;
     readonly [proxyTargetSymbol]: object;
@@ -260,6 +262,9 @@ export interface EditableTreeContext {
     get unwrappedRoot(): UnwrappedEditableField;
     set unwrappedRoot(data: ContextuallyTypedNodeData | undefined);
 }
+
+// @public
+export const editableTreeContextSymbol: unique symbol;
 
 // @public
 export type EditableTreeOrPrimitive = EditableTree | PrimitiveValue;

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -244,7 +244,13 @@ export interface EditableTree extends Iterable<EditableField>, ContextuallyTyped
 export interface EditableTreeContext {
     attachAfterChangeHandler(afterChangeHandler: (context: EditableTreeContext) => void): void;
     clear(): void;
+    // (undocumented)
+    commitTransaction(): void;
     free(): void;
+    // (undocumented)
+    get hasOpenTransaction(): boolean;
+    // (undocumented)
+    openTransaction(): void;
     prepareForEdit(): void;
     get root(): EditableField;
     set root(data: ContextuallyTypedNodeData | undefined);

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -68,6 +68,8 @@
     "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+    "@fluid-internal/tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/azure-client": "^1.0.2",
     "@hig/fonts": "^1.0.2",
     "@material-ui/core": "4.12.4",
     "@material-ui/lab": "4.0.0-alpha.61",
@@ -77,7 +79,8 @@
     "lodash": "^4.17.21",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-virtualized-auto-sizer": "^1.0.6"
+    "react-virtualized-auto-sizer": "^1.0.6",
+    "react-json-view": "^1.21.3"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/PropertyDDS/examples/property-inspector/src/azureApp.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/azureApp.tsx
@@ -1,0 +1,96 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { PropertyFactory } from "@fluid-experimental/property-properties";
+import { convertPSetSchema, registerSchemas } from "@fluid-experimental/schemas";
+import { AzureClient } from "@fluidframework/azure-client";
+import { ISharedTree, SharedTreeFactory, FullSchemaPolicy } from "@fluid-internal/tree";
+import { InsecureTinyliciousTokenProvider } from "@fluidframework/tinylicious-driver";
+import { IChannelFactory } from "@fluidframework/datastore-definitions";
+
+import { renderApp } from "./newInspector";
+import { getRootFieldSchema } from "./demoPersonData";
+
+class MySharedTree {
+    public static getFactory(): IChannelFactory {
+        return new SharedTreeFactory();
+    }
+
+    onDisconnect() {
+        console.warn("disconnected");
+    }
+}
+
+// In interacting with the service, we need to be explicit about whether we're creating a new document vs. loading
+// an existing one.  We also need to provide the unique ID for the document we are loading from.
+
+// In this app, we'll choose to create a new document when navigating directly to http://localhost:8080.
+// We'll also choose to interpret the URL hash as an existing document's
+// ID to load from, so the URL for a document load will look something like http://localhost:8080/#1596520748752.
+// These policy choices are arbitrary for demo purposes, and can be changed however you'd like.
+async function start(): Promise<void> {
+    // Register all schemas.
+    // It's important to register schemas before loading an existing document
+    // in order to process the changeset.
+    registerSchemas(PropertyFactory);
+
+    // when the document ID is not provided, create a new one.
+    const shouldCreateNew = location.hash.length === 0;
+    const documentId = !shouldCreateNew ? window.location.hash.substring(1) : "";
+
+    // // The getTinyliciousContainer helper function facilitates loading our container code into a Container and
+    // // connecting to a locally-running test service called Tinylicious.  This will look different when moving to a
+    // // production service, but ultimately we'll still be getting a reference to a Container object.  The helper
+    // // function takes the ID of the document we're creating or loading, the container code to load into it, and a
+    // // flag to specify whether we're creating a new document or loading an existing one.
+    // const [container, containerId] = await getTinyliciousContainer(documentId, ContainerFactory, shouldCreateNew);
+
+    const client = new AzureClient({
+        connection: {
+            type: "local",
+            endpoint: "http://localhost:7070",
+            tokenProvider: new InsecureTinyliciousTokenProvider(),
+        },
+    });
+
+    let res;
+    let containerId;
+    let container;
+    if (!documentId) {
+        res = await client.createContainer({
+            initialObjects: {
+                sharedTree: MySharedTree as any,
+            },
+        });
+        container = res.container;
+        containerId = await container.attach();
+    } else {
+        res = await client.getContainer(documentId, {
+            initialObjects: {
+                sharedTree: MySharedTree as any,
+            },
+        });
+        container = res.container;
+        containerId = documentId;
+    }
+
+    // update the browser URL and the window title with the actual container ID
+    location.hash = containerId;
+    document.title = containerId;
+
+    const sharedTree = container.initialObjects.sharedTree as ISharedTree;
+    const policy = sharedTree.storedSchema.policy as FullSchemaPolicy;
+    const [, OptionalFieldKind] = policy.fieldKinds.keys();
+	const schema = convertPSetSchema(policy, getRootFieldSchema(OptionalFieldKind));
+    sharedTree.storedSchema.update(schema);
+    // if (!documentId) {
+    //     const person = getPerson();
+        // sharedTree.root = { [typeNameSymbol]: personSchemaName };
+    // }
+
+    renderApp(sharedTree, document.getElementById("root")!);
+}
+
+start().catch((error) => console.error(error));

--- a/experimental/PropertyDDS/examples/property-inspector/src/demoPersonData.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/src/demoPersonData.ts
@@ -1,0 +1,139 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	brand,
+	TreeSchemaIdentifier,
+	FieldSchema,
+	FieldKindIdentifier,
+	Brand,
+	EditableField,
+	EditableTree,
+	LocalFieldKey,
+	valueSymbol,
+	typeNameSymbol,
+} from "@fluid-internal/tree";
+
+export const defaultPrimitiveValues = {
+	"Bool": false,
+	"String": "",
+	"Int8": 0,
+	"Uint8": 0,
+	"Int16": 0,
+	"Uint16": 0,
+	"Int32": 0,
+	"Int64": 0,
+	"Uint64": 0,
+	"Uint32": 0,
+	"Float32": 0,
+	"Float64": 0,
+};
+
+export const booleanSchemaName: TreeSchemaIdentifier = brand("Bool");
+export const int32SchemaName: TreeSchemaIdentifier = brand("Int32");
+export const stringSchemaName: TreeSchemaIdentifier = brand("String");
+export const float64SchemaName: TreeSchemaIdentifier = brand("Float64");
+export const phonesSchemaName: TreeSchemaIdentifier = brand("Test:Phones-1.0.0");
+export const addressSchemaName: TreeSchemaIdentifier = brand("Test:Address-1.0.0");
+export const mapStringSchemaName: TreeSchemaIdentifier = brand("map<string>");
+export const personSchemaName: TreeSchemaIdentifier = brand("Test:Person-1.0.0");
+export const complexPhoneSchemaName: TreeSchemaIdentifier = brand("Test:Phone-1.0.0");
+export const simplePhonesSchemaName: TreeSchemaIdentifier = brand("Test:SimplePhones-1.0.0");
+
+export function getRootFieldSchema(fieldKind: FieldKindIdentifier): FieldSchema {
+	return {
+		kind: fieldKind,
+		types: new Set([personSchemaName]),
+	};
+}
+
+export type Float64 = Brand<number, "editable-tree-inspector-demo.Float64"> & EditableTree;
+export type Int32 = Brand<number, "editable-tree-inspector-demo.Int32"> & EditableTree;
+export type Bool = Brand<boolean, "editable-tree-inspector-demo.Bool"> & EditableTree;
+
+export type ComplexPhone = EditableTree &
+	Brand<
+		{
+			number: string;
+			prefix: string;
+			extraPhones?: SimplePhones;
+		},
+		"editable-tree-inspector-demo.Test:Phone-1.0.0"
+	>;
+
+export type SimplePhones = EditableField &
+	Brand<string[], "editable-tree-inspector-demo.Test:SimplePhones-1.0.0">;
+
+export type Phones = EditableField &
+	Brand<
+		(Int32 | string | ComplexPhone | SimplePhones)[],
+		"editable-tree-inspector-demo.Test:Phones-1.0.0"
+	>;
+
+export type Address = EditableTree &
+	Brand<
+		{
+			zip: string | Int32;
+			street?: string;
+			city?: string;
+			country?: string;
+			phones?: Phones;
+			sequencePhones?: SimplePhones;
+		},
+		"editable-tree-inspector-demo.Test:Address-1.0.0"
+	>;
+
+export type Friends = EditableTree &
+	Brand<Record<LocalFieldKey, string>, "editable-tree-inspector-demo.Map<string>">;
+
+export type Person = EditableTree &
+	Brand<
+		{
+			name: string;
+			age?: Int32;
+			adult?: Bool;
+			salary?: Float64 | Int32;
+			friends?: Friends;
+			address?: Address;
+		},
+		"editable-tree-inspector-demo.Test:Person-1.0.0"
+	>;
+
+export function getPerson(): Person {
+	const age: Int32 = brand(35);
+	return {
+		// typed with built-in primitive type
+		name: "Adam",
+		// explicitly typed
+		age,
+		// inline typed
+		adult: brand<Bool>(true),
+		// Float64 | Int32
+		salary: {
+			[valueSymbol]: 10420.2,
+			[typeNameSymbol]: float64SchemaName,
+		},
+		friends: {
+			Mat: "Mat",
+		},
+		address: {
+			// string | Int32
+			zip: "99999",
+			street: "treeStreet",
+			// (Int32 | string | ComplexPhone | SimplePhones)[]
+			phones: [
+				"+49123456778",
+				123456879,
+				{
+					[typeNameSymbol]: complexPhoneSchemaName,
+					prefix: "0123",
+					number: "012345",
+					extraPhones: ["91919191"],
+				},
+				["112", "113"],
+			],
+		},
+	} as unknown as Person; // TODO: fix up these strong types to reflect unwrapping
+}

--- a/experimental/PropertyDDS/examples/property-inspector/src/newInspector.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/newInspector.tsx
@@ -1,0 +1,406 @@
+/* eslint-disable max-len */
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React, { useState } from "react";
+import ReactDOM from "react-dom";
+
+import { assert } from "@fluidframework/common-utils";
+import {
+    EditableTree,
+    typeNameSymbol,
+    valueSymbol,
+    EditableTreeContext,
+    indexSymbol,
+    keyFromSymbol,
+    FullSchemaPolicy,
+    isEditableField,
+    EditableField,
+    isGlobalFieldKey,
+    symbolIsFieldKey,
+    isPrimitive,
+    typeSymbol,
+    isUnwrappedNode,
+    brand,
+    getPrimaryField,
+    FieldKey,
+    ValueSchema,    
+    ContextuallyTypedNodeDataObject,
+    isWritableArrayLike,
+    PrimitiveValue,
+    ISharedTree,
+    rootFieldKey,
+    symbolFromKey,
+} from "@fluid-internal/tree";
+import {
+    IDataCreationOptions,
+    IInspectorTableProps,
+    InspectorTable,
+    ModalManager,
+    ModalRoot,
+    fetchRegisteredTemplates,
+    nameCellRenderer,
+    typeCellRenderer,
+    valueCellRenderer,
+    IEditableTreeRow,
+    IExpandedMap,
+} from "@fluid-experimental/property-inspector-table";
+
+import { Tabs, Tab, Button, Toolbar } from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
+import { MuiThemeProvider } from "@material-ui/core/styles";
+
+import AutoSizer from "react-virtualized-auto-sizer";
+
+import { theme } from "./theme";
+import { defaultPrimitiveValues, getPerson } from "./demoPersonData";
+
+const useStyles = makeStyles(
+    {
+        activeGraph: {
+            "flex-basis": "100%",
+            "z-index": 1,
+        },
+        horizontalContainer: {
+            display: "flex",
+            flex: "1",
+        },
+        inspectorContainer: {
+            "display": "flex",
+            "flex-basis": "100%",
+            "padding-left": "1px",
+        },
+        root: {
+            "display": "flex",
+            "flex-direction": "column",
+            "font-family": "ArtifaktElement, Helvetica, Arial",
+            "height": "100%",
+            "justify-content": "flex-start",
+            "overflow": "hidden",
+        },
+        sideNavContainer: {
+            display: "flex",
+        },
+        verticalContainer: {
+            "display": "flex",
+            "flex-basis": "100%",
+            "flex-direction": "column",
+            "justify-content": "space-between",
+        },
+        tableContainer: {
+            display: "flex",
+            height: "100%",
+            width: "100%",
+        },
+        editor: {
+            container: {
+                width: "100%",
+            },
+            body: {
+                width: undefined,
+                display: "flex",
+            },
+            outerBox: {
+                width: "100%",
+            },
+            contentBox: {
+                width: undefined,
+                flex: 1,
+            },
+            warningBox: {
+                width: "100%",
+            },
+        },
+    },
+    { name: "InspectorApp" },
+);
+
+export const handleDataCreationOptionGeneration = (
+    rowData: IEditableTreeRow,
+    nameOnly: boolean,
+): IDataCreationOptions => {
+    if (nameOnly) {
+        return { name: "property" };
+    }
+    const templates = fetchRegisteredTemplates();
+    return { name: "property", options: templates };
+};
+
+const tableProps: Partial<IInspectorTableProps> = {
+    columns: ["name", "value", "type"],
+    dataCreationHandler: async (rowData: IEditableTreeRow, name: string, typeid: string, context: string) => {
+        // avoid `undefined` as not supported by schema and UI
+        const value: PrimitiveValue = defaultPrimitiveValues[typeid];
+        if (isUnwrappedNode(rowData.parent)) {
+            (rowData.parent as ContextuallyTypedNodeDataObject)[brand<FieldKey>(name)] = {
+                [typeNameSymbol]: brand(typeid),
+                [valueSymbol]: value,
+            };
+        } else {
+            assert(isWritableArrayLike(rowData.parent), "expected writable ArrayLike");
+            rowData.parent[Number(name)] = {
+                [typeNameSymbol]: brand(typeid),
+                [valueSymbol]: value,
+            };
+        }
+    },
+    dataCreationOptionGenerationHandler: handleDataCreationOptionGeneration,
+    expandColumnKey: "name",
+    width: 1000,
+    height: 600,
+    expandAll: (data: EditableField): IExpandedMap => {
+        assert(isEditableField(data), "wrong root type");
+        return forEachNode(expandNode, { data }, {});
+    },
+};
+
+type nodeAction<T> = (result: T, parent: EditableField, pathPrefix: string, node: EditableTree, isSequence: boolean) => void;
+type addOnAction<T> = (result: T, parent: EditableField | EditableTree, pathPrefix: string) => void;
+
+function expandNode(
+    expanded: IExpandedMap,
+    parent: EditableField,
+    pathPrefix: string,
+    data: EditableTree,
+): void {
+    const id = getRowId(parent.fieldKey, data[indexSymbol], pathPrefix);
+    const nodeType = data[typeSymbol];
+    // TODO: e.g., how to properly schematize maps (`Serializable`)?
+    if (!isPrimitive(nodeType) || nodeType.value === ValueSchema.Serializable) {
+        expanded[id] = true;
+    }
+    forEachField(expandNode, expanded, { data }, id);
+}
+
+// TODO: maybe discuss alternatives on how global fields must be converted into row IDs.
+// Global fields in runtime are used as follows:
+// - as `GlobalFieldKeySymbol` (a symbol) => `Symbol(myGlobalField)` - used to read the tree data;
+// - as `GlobalFieldKey` (a string) => `myGlobalField` - used in `TreeSchema` and `JsonableTree`,
+// since global and local fields there are structurally separated.
+// Here we use "Symbol(myGlobalField)" (and not "myGlobalField") as a unique ID for this field,
+// since then a name clashing occurs iff one defines a local field "Symbol(myGlobalField)" for the same node,
+// and it will be more probable if we'll use just a string "myGlobalField" instead.
+// We might introduce a new special syntax for the IDs of global fields to avoid clashing,
+// but it seems that the default syntax already provides a very good safeguard though.
+const getRowId = (fieldKey: FieldKey, nodeIndex: number, pathPrefix: string): string =>
+    `${pathPrefix}/${String(fieldKey)}[${nodeIndex}]`;
+
+function stringifyKey(fieldKey: FieldKey): string {
+    if (isGlobalFieldKey(fieldKey) && symbolIsFieldKey(fieldKey)) {
+        return keyFromSymbol(fieldKey);
+    }
+    return fieldKey;
+}
+
+function nodeToTableRow(
+    rows: IEditableTreeRow[],
+    parent: EditableField,
+    pathPrefix: string,
+    data: EditableTree,
+    isSequenceNode = false,
+): void {
+    const fieldKey = parent.fieldKey;
+    const nodeIndex = data[indexSymbol];
+    const id = getRowId(fieldKey, nodeIndex, pathPrefix);
+    // TODO: this is a workaround, which must be replaced with the `EditableTreeUpPath` (not yet implemented)
+    // in order to get, if the field is a root field.
+    // For `EditableTreeUpPath`, see https://github.com/microsoft/FluidFramework/pull/12810#issuecomment-1303949419
+    const keyAsString = pathPrefix === "" ? "Person" : stringifyKey(fieldKey);
+    const name = isSequenceNode ? `[${nodeIndex}]` : keyAsString;
+    const children = forEachField(nodeToTableRow, [], { data }, id, addNewDataLine);
+    // TODO: currently, the whole story around arrays is not well defined neither implemented.
+    // Prevent to create fields under a node already having a primary field.
+    const nodeType = data[typeSymbol];
+    if (!(isPrimitive(nodeType) || getPrimaryField(nodeType) !== undefined) || nodeType.value === ValueSchema.Serializable) {
+        addNewDataLine(children, data, id);
+    }
+    const value = data[valueSymbol];
+    const typeid = data[typeNameSymbol];
+    rows.push({
+        id,
+        name,
+        context: "single",
+        children,
+        isReference: false,
+        value,
+        typeid,
+        parent,
+        data,
+        isEditableTree: true,
+    });
+}
+
+function addNewDataLine(
+    rows: IEditableTreeRow[],
+    parent: EditableField | EditableTree,
+    pathPrefix: string,
+): void {
+    rows.push({
+        id: `${pathPrefix}/Add`,
+        isNewDataRow: true,
+        parent,
+        value: "",
+        typeid: "",
+        name: "",
+        isEditableTree: true,
+    });
+}
+
+function forEachField<T>(
+    nodeAction: nodeAction<T>,
+    data: T,
+    { data: node }: Partial<IEditableTreeRow>,
+    pathPrefix: string,
+    addOnIfSequenceField?: addOnAction<T>,
+): T {
+    assert(isUnwrappedNode(node), "Expected node");
+    for (const field of node) {
+        forEachNode(nodeAction, { data: field }, data, pathPrefix, addOnIfSequenceField);
+    }
+    return data;
+}
+
+function isSequenceField(field: EditableField): boolean {
+    const [,, SequenceKind] = (field.context.schema.policy as FullSchemaPolicy).fieldKinds.keys();
+    return field.fieldSchema.kind === SequenceKind;
+}
+
+function forEachNode<T>(
+    nodeAction: nodeAction<T>,
+    { data: field }: Partial<IEditableTreeRow>,
+    result: T,
+    pathPrefix = "",
+    addOnIfSequenceField?: addOnAction<T>,
+): T {
+    assert(isEditableField(field), "Expected field");
+    const isSequence = isSequenceField(field);
+    for (let index = 0; index < field.length; index++) {
+        const node = field.getNode(index);
+        nodeAction(result, field, pathPrefix, node, isSequence);
+    }
+    if ((isEmptyRoot(field) || isSequence) && addOnIfSequenceField !== undefined) {
+        addOnIfSequenceField(result, field, pathPrefix);
+    }
+    return result;
+}
+
+const isEmptyRoot = (field: EditableField): boolean => field.fieldKey === symbolFromKey(rootFieldKey) && field.length === 0;
+
+const editableTreeTableProps: Partial<IInspectorTableProps> = {
+    ...tableProps,
+    columnsRenderers: {
+        name: nameCellRenderer,
+        value: valueCellRenderer,
+        type: typeCellRenderer,
+    },
+    toTableRows: (rowData: IEditableTreeRow): IEditableTreeRow[] => {
+        return forEachNode(nodeToTableRow, rowData, [], "", addNewDataLine);
+    },
+};
+
+interface TabPanelProps {
+    children?: React.ReactNode;
+    index: number;
+    value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+    const { children, value, index, ...other } = props;
+
+    return (
+        <div role="tabpanel" hidden={value !== index} id={`simple-tabpanel-${index}`} {...other}>
+            {value === index && children}
+        </div>
+    );
+}
+
+export const InspectorApp = (props: any) => {
+    const classes = useStyles();
+    const context = props.data as EditableTreeContext;
+    const { root } = context;
+
+    // const [json, setJson] = useState(editableTree);
+    const [tabIndex, setTabIndex] = useState(0);
+    const [pendingTransaction, setPendingTransaction] = useState(context.hasOpenTransaction);
+
+    // const onJsonEdit = ({ updated_src }) => {
+    //     setJson(updated_src);
+    // };
+
+    return (
+        <MuiThemeProvider theme={theme}>
+            <ModalManager>
+                <ModalRoot />
+                <div className={classes.root}>
+                    <div className={classes.horizontalContainer}>
+                        {/* <div className={classes.editor}>
+                            <ReactJson src={json as EditableTree} onEdit={onJsonEdit}/>
+                        </div> */}
+                        <div className={classes.verticalContainer}>
+                            <Toolbar>
+                                <Button onClick={() => (context.root = getPerson())} variant="outlined">Demo Person</Button>
+                                <Button onClick={() => {
+                                    context.openTransaction();
+                                    setPendingTransaction(true);
+                                }} variant="outlined" disabled={pendingTransaction}>Open Transaction</Button>
+                                <Button onClick={() => {
+                                    context.commitTransaction();
+                                    setPendingTransaction(false);
+                                }} variant="outlined" disabled={!pendingTransaction}>Commit</Button>
+                                <Button onClick={() => {
+                                    context.abortTransaction();
+                                    setPendingTransaction(false);
+                                }} variant="outlined" disabled={!pendingTransaction}>Abort</Button>
+                            </Toolbar>
+                            <Tabs
+                                value={tabIndex}
+                                onChange={(event, newTabIndex) => setTabIndex(newTabIndex)}
+                            >
+                                <Tab label="Editable Tree" id="tab-editableTree" />
+                                {/* <Tab label="JSON" id="tab-json"/> */}
+                            </Tabs>
+                            <div className={classes.tableContainer}>
+                                <AutoSizer>
+                                    {({ width, height }) => (
+                                        <div className={classes.horizontalContainer}>
+                                            {/* <TabPanel value={tabIndex} index={1}>
+                                                <InspectorTable
+                                                    {...tableProps}
+                                                    width={width}
+                                                    height={height}
+                                                    {...props}
+                                                />
+                                            </TabPanel> */}
+                                            <TabPanel value={tabIndex} index={0}>
+                                                <InspectorTable
+                                                    readOnly={false}
+                                                    {...editableTreeTableProps}
+                                                    width={width}
+                                                    height={height}
+                                                    {...props}
+                                                    data={root}
+                                                />
+                                            </TabPanel>
+                                        </div>
+                                    )}
+                                </AutoSizer>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </ModalManager>
+        </MuiThemeProvider>
+    );
+};
+
+export function renderApp(data: ISharedTree, element: HTMLElement) {
+    const { context } = data;
+    const render = () => {
+        context.clear();
+        ReactDOM.render(<InspectorApp data={context} />, element);
+    };
+    context.attachAfterChangeHandler(render);
+    render();
+}

--- a/experimental/PropertyDDS/examples/property-inspector/webpack.config.js
+++ b/experimental/PropertyDDS/examples/property-inspector/webpack.config.js
@@ -9,8 +9,10 @@ const webpack = require("webpack");
 module.exports = env => {
     const htmlTemplate = "./src/index.html";
     return {
-        devtool: "inline-source-map",
-        entry: "./src/app.tsx",
+        devtool: "eval-source-map",
+        entry: {
+            app: "./src/azureApp.tsx"
+        },
         mode: "development",
         devServer: {
             port: 9000
@@ -49,7 +51,15 @@ module.exports = env => {
             })
         ],
         resolve: {
-            extensions: [".ts", ".tsx", ".js"]
+            extensions: [".ts", ".tsx", ".js"],
+            fallback: {
+                dgram: false,
+                fs: false,
+                net: false,
+                tls: false,
+                child_process: false,
+                "console": require.resolve("console-browserify"),
+            }
         },
     }
 }

--- a/experimental/PropertyDDS/examples/schemas/package.json
+++ b/experimental/PropertyDDS/examples/schemas/package.json
@@ -29,6 +29,11 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "tsc": "tsc"
   },
+  "dependencies": {
+    "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+    "@fluid-experimental/property-properties": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+    "@fluid-internal/tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+  },
   "devDependencies": {
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",

--- a/experimental/PropertyDDS/examples/schemas/src/index.ts
+++ b/experimental/PropertyDDS/examples/schemas/src/index.ts
@@ -3,12 +3,16 @@
  * Licensed under the MIT License.
  */
 import { schemas as SQUARES_DEMO_SCHEMAS } from "./squares_demo";
+import PERSON_SCHEMAS from "./person_demo";
+
+export { convertPSetSchema } from "./schemaConverter";
 
 export { registerSchemas } from "./schemasRegisterer";
 
 // eslint-disable-next-line unicorn/prefer-export-from
-export { SQUARES_DEMO_SCHEMAS };
+export { SQUARES_DEMO_SCHEMAS, PERSON_SCHEMAS };
 
 export const ALL_SCHEMAS = {
     SQUARES_DEMO_SCHEMAS,
+    PERSON_SCHEMAS,
 };

--- a/experimental/PropertyDDS/examples/schemas/src/person_demo/index.ts
+++ b/experimental/PropertyDDS/examples/schemas/src/person_demo/index.ts
@@ -1,0 +1,80 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export default {
+    geodesicLocation: {
+        typeid: "Test:GeodesicLocation-1.0.0",
+        properties: [
+            { id: "lat", typeid: "Float64" },
+            { id: "lon", typeid: "Float64" },
+        ],
+    },
+    cartesianLocation: {
+        typeid: "Test:CartesianLocation-1.0.0",
+        properties: [{ id: "coords", typeid: "Float64", context: "array" }],
+    },
+    simplePhones: {
+        typeid: "Test:SimplePhones-1.0.0",
+        properties: [{ id: "phone", typeid: "String", context: "array" }],
+    },
+    complexPhone: {
+        typeid: "Test:Phone-1.0.0",
+        properties: [
+            { id: "number", typeid: "String" },
+            { id: "prefix", typeid: "String" },
+            {
+                id: "extraPhones",
+                typeid: "Test:SimplePhones-1.0.0",
+                optional: true,
+            },
+        ],
+    },
+    phones: {
+        typeid: "Test:Phones-1.0.0",
+        properties: [
+            { id: "phoneAsString", typeid: "String", context: "array" },
+            { id: "phoneAsInt32", typeid: "Int32", context: "array" },
+            {
+                id: "phoneAsComplexObject",
+                typeid: "Test:Phone-1.0.0",
+                context: "array",
+            },
+            {
+                id: "phoneAsArray",
+                typeid: "Test:SimplePhones-1.0.0",
+                context: "array",
+            },
+        ],
+    },
+    address: {
+        typeid: "Test:Address-1.0.0",
+        inherits: [
+            "NodeProperty",
+            "Test:GeodesicLocation-1.0.0",
+            "Test:CartesianLocation-1.0.0",
+        ],
+        properties: [
+            { id: "zip", typeid: "String" },
+            { id: "zip", typeid: "Int32" },
+            { id: "street", typeid: "String", optional: true },
+            { id: "city", typeid: "String", optional: true },
+            { id: "country", typeid: "String", optional: true },
+            { id: "phones", typeid: "Test:Phones-1.0.0", optional: true },
+        ],
+    },
+    person: {
+        typeid: "Test:Person-1.0.0",
+        inherits: ["NodeProperty"],
+        properties: [
+            { id: "name", typeid: "String" },
+            { id: "age", typeid: "Int32", optional: true },
+            { id: "adult", typeid: "Bool", optional: true },
+            { id: "salary", typeid: "Float64", optional: true },
+            { id: "salary", typeid: "Int32", optional: true },
+            { id: "address", typeid: "Test:Address-1.0.0", optional: true },
+            { id: "friends", typeid: "String", context: "map", optional: true },
+        ],
+    },
+};

--- a/experimental/PropertyDDS/examples/schemas/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/examples/schemas/src/schemaConverter.ts
@@ -1,0 +1,336 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// eslint-disable-next-line import/no-nodejs-modules
+import { fail } from "assert";
+import {
+    brand,
+    emptyField,
+    EmptyKey,
+    FieldKindIdentifier,
+    FieldSchema,
+    LocalFieldKey,
+    rootFieldKey,
+    SchemaData,
+    TreeSchema,
+    TreeSchemaIdentifier,
+    ValueSchema,
+    FullSchemaPolicy,
+} from "@fluid-internal/tree";
+import {
+    PropertyFactory,
+    PropertyTemplate,
+} from "@fluid-experimental/property-properties";
+import { TypeIdHelper } from "@fluid-experimental/property-changeset";
+
+const booleanTypes = new Set(["Bool"]);
+const numberTypes = new Set([
+    "Int8",
+    "Uint8",
+    "Int16",
+    "Uint16",
+    "Int32",
+    "Int64",
+    "Uint64",
+    "Uint32",
+    "Float32",
+    "Float64",
+]);
+const primitiveTypes = new Set([
+    "Bool",
+    "String",
+    "Int8",
+    "Uint8",
+    "Int16",
+    "Uint16",
+    "Int32",
+    "Int64",
+    "Uint64",
+    "Uint32",
+    "Float32",
+    "Float64",
+]);
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type Context = {
+    typeid: TreeSchemaIdentifier;
+    context: string;
+    types?: Set<TreeSchemaIdentifier>;
+};
+
+export function convertPSetSchema(policy: FullSchemaPolicy, rootFieldSchema: FieldSchema): SchemaData {
+    const [ValueFieldKind, OptionalFieldKind, SequenceFieldKind] = policy.fieldKinds.keys();
+    const treeSchema = new Map();
+    const rootTypes = rootFieldSchema.types ?? fail("Expected root types");
+
+    // Extract all referenced typeids for the schema
+    const unprocessedTypeIds: string[] = [...rootTypes];
+    const referencedTypeIDs = new Map<TreeSchemaIdentifier, Context>();
+
+    while (unprocessedTypeIds.length > 0) {
+        const unprocessedTypeID = unprocessedTypeIds.pop() ?? fail("fail");
+
+        const context: Context = {
+            typeid: brand(unprocessedTypeID),
+            context: "single",
+        };
+        referencedTypeIDs.set(brand(unprocessedTypeID), context);
+
+        const schemaTemplate = PropertyFactory.getTemplate(unprocessedTypeID);
+        if (schemaTemplate === undefined) {
+            throw new Error(`Unknown typeid: ${unprocessedTypeID}`);
+        }
+        const dependencies = PropertyTemplate.extractDependencies(
+            schemaTemplate
+        ) as TreeSchemaIdentifier[];
+        for (const dependencyTypeId of dependencies) {
+            if (!referencedTypeIDs.has(dependencyTypeId)) {
+                unprocessedTypeIds.push(dependencyTypeId);
+            }
+        }
+
+        // Extract context information (i.e. array, map and set types)
+        const extractContexts = (properties: any[]): void => {
+            for (const property of properties || []) {
+                if (property.properties) {
+                    // We have a nested set of properties
+                    // TODO: We have to create a corresponding nested type
+                    extractContexts(property.properties);
+                }
+                if (
+                    property.context !== undefined &&
+                    property.context !== "single"
+                ) {
+                    if (property.context !== "array") {
+                        referencedTypeIDs.set(
+                            brand(`${property.context}<${property.typeid}>`),
+                            {
+                                typeid: property.typeid,
+                                context: property.context,
+                            }
+                        );
+                        return;
+                    }
+                    context.context = property.context;
+                    if (context.types === undefined) {
+                        context.types = new Set();
+                    }
+                    context.types.add(property.typeid);
+                }
+                if (TypeIdHelper.isPrimitiveType(property.typeid)) {
+                    referencedTypeIDs.set(property.typeid, {
+                        typeid: property.typeid,
+                        context: "single",
+                    });
+                }
+            }
+        };
+        extractContexts(schemaTemplate.properties);
+    }
+
+    for (const type of primitiveTypes) {
+        const typeid: TreeSchemaIdentifier = brand(type);
+        if (!referencedTypeIDs.has(typeid)) {
+            referencedTypeIDs.set(typeid, {
+                typeid,
+                context: "single",
+            });
+        }
+    }
+
+    // Now we create the actual schemas, since we are now able to reference the dependent types
+    for (const [referencedTypeId, context] of referencedTypeIDs) {
+        if (treeSchema.get(referencedTypeId) !== undefined) {
+            continue;
+        }
+        let typeSchema: TreeSchema | undefined;
+
+        if (context.context === "single") {
+            if (TypeIdHelper.isPrimitiveType(referencedTypeId)) {
+                // if (context.typeid === "String") {
+                //     // String is a special case, we actually have to represent it as a sequence
+                //     typeSchema = {
+                //         localFields: new Map<LocalFieldKey, FieldSchema>([
+                //             [
+                //                 EmptyKey,
+                //                 {
+                //                     kind: fieldKinds.sequence,
+                //                     types: new Set([
+                //                         // TODO: Which type do we use for characters?
+                //                     ]),
+                //                 },
+                //             ],
+                //         ]),
+                //         globalFields: new Set(),
+                //         extraLocalFields: emptyField,
+                //         extraGlobalFields: false,
+                //         value: ValueSchema.Nothing,
+                //     };
+                // } else {
+                let valueType: ValueSchema;
+                // if (context.isEnum) {
+                //     valueType = ValueSchema.Number;
+                if (context.typeid.startsWith("Reference<")) {
+                    valueType = ValueSchema.String;
+                } else if (booleanTypes.has(context.typeid)) {
+                    valueType = ValueSchema.Boolean;
+                } else if (numberTypes.has(context.typeid)) {
+                    valueType = ValueSchema.Number;
+                } else if (context.typeid === "String") {
+                    valueType = ValueSchema.String;
+                } else {
+                    throw new Error(
+                        `Unknown primitive typeid: ${context.typeid}`
+                    );
+                }
+
+                typeSchema = {
+                    localFields: new Map(),
+                    globalFields: new Set(),
+                    extraLocalFields: emptyField,
+                    extraGlobalFields: false,
+                    value: valueType,
+                };
+                // }
+            } else {
+                if (context.typeid === "NodeProperty") {
+                    typeSchema = {
+                        localFields: new Map(),
+                        globalFields: new Set(),
+                        extraLocalFields: {
+                            kind: OptionalFieldKind,
+                        },
+                        extraGlobalFields: false,
+                        value: ValueSchema.Nothing,
+                    };
+                } else {
+                    const localFields = new Map<LocalFieldKey, FieldSchema>();
+                    const inheritanceChain =
+                        PropertyFactory.getAllParentsForTemplate(
+                            context.typeid
+                        );
+                    inheritanceChain.push(context.typeid);
+
+                    for (const typeIdInInheritanceChain of inheritanceChain) {
+                        if (typeIdInInheritanceChain === "NodeProperty") {
+                            continue;
+                        }
+
+                        const schema = PropertyFactory.getTemplate(
+                            typeIdInInheritanceChain
+                        );
+                        if (schema === undefined) {
+                            throw new Error(
+                                `Unknown typeid referenced: ${typeIdInInheritanceChain}`
+                            );
+                        }
+                        for (const property of schema.properties) {
+                            if (property.properties) {
+                                // TODO: Handle nested properties
+                            } else {
+                                let currentTypeid = property.typeid;
+                                if (
+                                    property.context &&
+                                    property.context !== "single"
+                                ) {
+                                    currentTypeid = `${property.context}<${
+                                        property.typeid || ""
+                                    }>`;
+                                }
+                                const fieldKey: LocalFieldKey = brand(property.id);
+                                if (!localFields.has(fieldKey)) {
+                                    localFields.set(fieldKey, {
+                                        kind: property.optional
+                                            ? OptionalFieldKind
+                                            : ValueFieldKind,
+                                        types: new Set([currentTypeid]),
+                                    });
+                                } else {
+                                    const types = localFields.get(fieldKey)?.types ?? fail("never");
+                                    localFields.set(fieldKey, {
+                                        kind: property.optional
+                                            ? OptionalFieldKind
+                                            : ValueFieldKind,
+                                        types: new Set([...types, currentTypeid]),
+                                    });
+                                }
+                            }
+                        }
+                    }
+
+                    typeSchema = {
+                        localFields,
+                        globalFields: new Set(),
+                        extraLocalFields: PropertyFactory.inheritsFrom(
+                            context.typeid,
+                            "NodeProperty"
+                        )
+                            ? { kind: OptionalFieldKind }
+                            : emptyField,
+                        extraGlobalFields: false,
+                        value: ValueSchema.Nothing,
+                    };
+                }
+            }
+        } else {
+            const kind: FieldKindIdentifier =
+                context.context === "array"
+                    ? SequenceFieldKind
+                    : OptionalFieldKind;
+
+            const fieldType = {
+                kind,
+                types: context.types ?? new Set([context.typeid]),
+            };
+            switch (context.context) {
+                case "map":
+                case "set":
+                    typeSchema = {
+                        localFields: new Map(),
+                        globalFields: new Set(),
+                        extraLocalFields: fieldType,
+                        extraGlobalFields: false,
+                        value: ValueSchema.Serializable,
+                    };
+
+                    break;
+                case "array":
+                    typeSchema = {
+                        localFields: new Map<LocalFieldKey, FieldSchema>([
+                            [EmptyKey, fieldType],
+                        ]),
+                        globalFields: new Set(),
+                        extraLocalFields: emptyField,
+                        extraGlobalFields: false,
+                        value: ValueSchema.Nothing,
+                    };
+                    break;
+                default:
+                    throw new Error(
+                        `Unknown context in typeid: ${context.context}`
+                    );
+            }
+        }
+
+        treeSchema.set(referencedTypeId, typeSchema);
+    }
+    const fullSchemaData: SchemaData = {
+        treeSchema,
+        globalFieldSchema: new Map([[rootFieldKey, rootFieldSchema]]),
+    };
+    return fullSchemaData;
+}
+
+// Concepts currently not mapped / represented in the compiled schema:
+//
+// * Annotations
+// * Length constraints for arrays / strings
+// * Constants
+// * Values for enums
+// * Default values

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -41,6 +41,8 @@
     "tsc": "tsc"
   },
   "dependencies": {
+    "@fluidframework/common-utils": "^1.0.0",
+    "@fluid-internal/tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@hig/fonts": "^1.0.2",
     "@material-ui/core": "4.12.4",
     "@material-ui/lab": "4.0.0-alpha.61",

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
@@ -593,8 +593,12 @@ class InspectorTable<
   // @TODO turn it private when refactoring editing workflow
   private readonly handleCreateData = async (rowData: T, name: string, type: string, context: string) => {
     if (this.dataCreation) {
-      await this.props.dataCreationHandler!(rowData, name, type, context);
+      // TODO: this change appeared to be required since otherwise (having it below the `await` line)
+      // it is not executed due to unknown reason, letting the `renderCreationRow` to be called again
+      // with a wrong `showFormRowID` and causing the app to crash due to the freed EditableTree root.
+      // To be investigated.
       this.setState({ showFormRowID: "0" });
+      await this.props.dataCreationHandler!(rowData, name, type, context);
     }
   };
 
@@ -743,7 +747,7 @@ class InspectorTable<
       const tableRows = this.state.tableRows;
       tableRows.forEach((item) => {
         this.traverseTree(item, (item) => {
-          if (item.children && !item.isReference) {
+          if (item.children && !item.isReference && item.children[0] !== undefined) {
             if (item.children[0].context === "d") {
               this.props.fillExpanded({ [item.id]: true }, [item], this.props, this.toTableRowOptions);
             }

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTableTypes.ts
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTableTypes.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { EditableField, EditableTree, Value } from "@fluid-internal/tree";
 import { BaseProxifiedProperty } from "@fluid-experimental/property-proxy";
 import { BaseProperty } from "@fluid-experimental/property-properties";
 
@@ -62,6 +63,7 @@ export interface IRowData<T = never> {
 	isReference?: boolean;
 	context?: string;
   isNewDataRow?: boolean;
+  isEditableTree?: boolean;
 }
 
 export type IToTableRowsProps = Pick<IInspectorTableProps,
@@ -107,6 +109,20 @@ export interface IInspectorRow extends IRowData<BaseProxifiedProperty>{
   parentIsConstant: boolean;
   propertyId: string;
 }
+
+export interface IEditableTreeRow extends IRowData<EditableTree | EditableField> {
+  context?: string;
+  typeid: string;
+  isReference?: boolean;
+  parent: EditableTree | EditableField;
+  value?: Value;
+  name: string;
+}
+
+export function isEditableTreeRow(data: IInspectorRow | IEditableTreeRow): data is IEditableTreeRow {
+  return data.isEditableTree ?? false;
+}
+
 /**
  * The interface for the cell data getter function parameter
  */

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/NewDataForm.stories.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/NewDataForm.stories.tsx
@@ -7,7 +7,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { InspectorDecorator } from './InspectorDecorator';
 import { InspectorTableDecorator } from './InspectorTableDecorator';
-import { IInspectorRow } from './InspectorTableTypes';
+import { IEditableTreeRow, IInspectorRow } from './InspectorTableTypes';
 import { NewDataForm } from './NewDataForm';
 
 storiesOf('NewDataForm', module)
@@ -18,7 +18,7 @@ storiesOf('NewDataForm', module)
       <div style={{border: '1px solid rgba(1,1,1,0)', width: '400px', fontFamily: 'sans-serif'}}>
           <NewDataForm
             onCancelCreate={() => alert('onCancelCreate called')}
-            onDataCreate={(rowData: IInspectorRow, name: string, typeid: string, context: string) =>
+            onDataCreate={(rowData: IInspectorRow | IEditableTreeRow, name: string, typeid: string, context: string) =>
               alert(
                 'onDataCreate called with the following parameters:' +
                 '\nname: ' + name +

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/NewDataForm.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/NewDataForm.tsx
@@ -4,6 +4,7 @@
  */
 
 import { ContainerProperty, PropertyFactory } from "@fluid-experimental/property-properties";
+import { isEditableField, isUnwrappedNode, TreeTypeSet, typeNameSymbol } from "@fluid-internal/tree";
 import Button from "@material-ui/core/Button";
 import InputAdornment from "@material-ui/core/InputAdornment";
 import { makeStyles } from "@material-ui/core/styles";
@@ -27,7 +28,7 @@ import {
 } from "./DecoratedSelect";
 import { ErrorPopup } from "./ErrorPopup";
 import { ErrorTooltip } from "./ErrorTooltip";
-import { IInspectorRow } from "./InspectorTableTypes";
+import { IEditableTreeRow, IInspectorRow, isEditableTreeRow } from "./InspectorTableTypes";
 import {
   SvgIcon,
 } from "./SVGIcon";
@@ -116,7 +117,7 @@ export interface INewDataFormProps {
   /**
    * Callback that is executed on create.
    */
-  onDataCreate: (rowData: IInspectorRow, name: string, typeid: string, context: string) => void;
+  onDataCreate: (rowData: IInspectorRow | IEditableTreeRow, name: string, typeid: string, context: string) => void;
   /**
    * The available options.
    */
@@ -124,7 +125,7 @@ export interface INewDataFormProps {
   /**
    * Data Inspector row data for current row
    */
-  rowData: IInspectorRow;
+  rowData: IInspectorRow | IEditableTreeRow;
 }
 
 /**
@@ -136,6 +137,15 @@ const addCorrespondingSvgIcon = (propOptions: INewDataFormOptions[]): DecoratedS
     ...item,
     icon: <TypeIcon typeId={item.label} />,
   }));
+};
+
+const getSiblingIDs = (rowData: IEditableTreeRow | IInspectorRow): string[] => {
+  if (!isEditableTreeRow(rowData)) {
+    return (rowData.parent as ContainerProperty).getIds() ?? [];
+  }
+  return isUnwrappedNode(rowData.parent) ? [...rowData.parent]
+    .filter((field) => (field.fieldKey in rowData.parent))
+    .map((field) => String(field.fieldKey)) : [];
 };
 
 const contextOptions: DecoratedSelectOptionsType = [
@@ -151,16 +161,42 @@ const setContext: IDecoratedSelectOptionType = { value: "set", label: "Set", ico
 export const NewDataForm: React.FunctionComponent<INewDataFormProps> = (props) => {
   const { options, onDataCreate, onCancelCreate, rowData } = props;
   const classes = useStyles();
-  const [inputName, setInputName] = useState("");
+  // TODO: all changes in this file are very rough. A good implementation with EditableTree
+  // will probably require new UIs to create fields / nodes.
+  // It could be a node or a field of EditableTree. A field means we are in a sequence i.e.:
+  // - we are in a field, and fields have no types
+  // - we can insert nodes only within the sequence or as an append to the tail
+  // - since currently UI does not support "inline" inserts, we always append meaning
+  // that the only possible name is a length of the sequence.
+  const [inputName, setInputName] = isEditableTreeRow(rowData) && isEditableField(rowData.parent)
+    ? useState(String(rowData.parent.length))
+    : useState("");
   const [isCreating, setCreating] = useState(false);
   const [isNamedProp, setIsNamedProp] = useState(false);
 
-  const siblingIds = rowData.parent ? (rowData.parent as ContainerProperty).getIds() : [];
+  let parentTypeId;
+  let parentContext = "single";
+  let supportedParentTypes: TreeTypeSet;
+  if (isEditableTreeRow(rowData)) {
+    if (isUnwrappedNode(rowData.parent)) {
+      parentTypeId = rowData.parent[typeNameSymbol];
+    } else if (isEditableField(rowData.parent)) {
+      supportedParentTypes = rowData.parent.fieldSchema.types ?? new Set();
+    }
+  } else if (rowData.parent) {
+    parentTypeId = rowData.parent.getTypeid();
+    parentContext = rowData.parent.getContext();
+  }
 
   // Reshape the 'options' array which into an object suitable for consumption by react-select.
   // Also into each option add an SVG icon corresponding to its label.
   const typeOptions: DecoratedSelectGroupedOptionsType =
-    options.map((group) => ({ label: group[0], options: addCorrespondingSvgIcon(group[1]) }));
+    options.map(([label, types ]) => ({ label, options: addCorrespondingSvgIcon(
+      types.filter(({ value }) => {
+        if (supportedParentTypes === undefined) return true;
+        return supportedParentTypes.has(value);
+      })
+    ) })).filter(({ options }) => options.length > 0);
 
   let listOfContextOptions: DecoratedSelectOptionsType = contextOptions;
   let defaultTypeOption: IDecoratedSelectOptionType;
@@ -171,7 +207,7 @@ export const NewDataForm: React.FunctionComponent<INewDataFormProps> = (props) =
       const subTypeOptions: IDecoratedSelectOptionType[] = [];
       subType.options.forEach((typ) => {
         const parentTypes = PropertyFactory.getAllParentsForTemplate(typ.value);
-        if (typ.value === rowData.parent!.getTypeid() || parentTypes.includes(rowData.parent!.getTypeid())) {
+        if (typ.value === parentContext || parentTypes.includes(parentContext)) {
           subTypeOptions.push(typ);
         }
       });
@@ -188,11 +224,11 @@ export const NewDataForm: React.FunctionComponent<INewDataFormProps> = (props) =
   // Choose default value depending on the context
   // For "single" context  or when parent is undefined we choose the first option from the "options" property
   // For sets, maps and arrays we need to extract the typeid of parent collection and set contextOptions only to single
-  if (!rowData.parent || rowData.parent!.getContext() === "single") {
+  if (!rowData.parent || parentContext === "single") {
     defaultTypeOption = typeOptions[0].options[0];
   } else {
     excludeUninheritedTemplates();
-    defaultTypeOption = filterTypeOptions(rowData.parent!.getTypeid());
+    defaultTypeOption = filterTypeOptions(parentTypeId);
     listOfContextOptions = contextOptions.filter((cOption) => cOption.value === "single");
   }
 
@@ -205,7 +241,7 @@ export const NewDataForm: React.FunctionComponent<INewDataFormProps> = (props) =
     const parentTypeId = selectedTypeOption.value;
     const parentTypes = PropertyFactory.getAllParentsForTemplate(parentTypeId);
     // sets can be created only for properties inheriting from NamedProperty
-    if (rowData.parent && rowData.parent.getContext() === "single" &&
+    if (rowData.parent && parentContext === "single" &&
       (selectedTypeOption.value === "NamedProperty" || parentTypes.includes("NamedProperty"))) {
       setIsNamedProp(true);
     } else {
@@ -243,7 +279,8 @@ export const NewDataForm: React.FunctionComponent<INewDataFormProps> = (props) =
     </Button>
   );
 
-  const isSiblingFound = siblingIds.includes(inputName);
+  const isSiblingFound = getSiblingIDs(rowData).includes(inputName);
+  const isSequence = isEditableTreeRow(rowData) && isEditableField(rowData.parent);
   const createBtn = (
     <Button
       id="createDataButton"
@@ -252,7 +289,7 @@ export const NewDataForm: React.FunctionComponent<INewDataFormProps> = (props) =
       style={{ minWidth: "0px" }}
       className={classNames(classes.button, classes.createButton)}
       disabled={isSiblingFound || rowData.parent &&
-         (!notNamedCollections.includes(rowData.parent.getContext()) && !inputName.trim())}
+         (!notNamedCollections.includes(parentContext) && !inputName.trim())}
       onClick={handleCreateData}
     >
       {isCreating ? "Creating" : "Create"}
@@ -285,7 +322,7 @@ export const NewDataForm: React.FunctionComponent<INewDataFormProps> = (props) =
   );
 
   const nameInput = (height: number, width: number) => {
-    if (rowData.parent && notNamedCollections.includes(rowData.parent!.getContext())) {
+    if (rowData.parent && notNamedCollections.includes(parentContext)) {
       return (<div />);
     }
     const selectedTypeOrCollectionLabel = selectedContainerOption.value === "single"
@@ -339,6 +376,7 @@ export const NewDataForm: React.FunctionComponent<INewDataFormProps> = (props) =
           onChange={handleInputChange}
           onKeyPress={handleKeyPress}
           InputProps={startAndEndAdornment}
+          disabled={isSequence}
         />
       </div>
     );

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyViews/Boolean.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyViews/Boolean.tsx
@@ -3,11 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerProperty } from "@fluid-experimental/property-properties";
 import Switch, { SwitchProps } from "@material-ui/core/Switch";
 import * as React from "react";
 import { IEditableValueCellProps, IInspectorRow } from "../InspectorTableTypes";
-import { getPropertyValue } from "../propertyInspectorUtils";
 
 type BooleanProps = (IEditableValueCellProps & {
   onSubmit: (val: boolean, props: IEditableValueCellProps) => void;
@@ -17,15 +15,13 @@ type BooleanProps = (IEditableValueCellProps & {
 
 export const BooleanView: React.FunctionComponent<BooleanProps> = (props) => {
   const {
-    followReferences,
     onSubmit,
     SwitchProps: switchProps,
     rowData,
     readOnly,
   } = props;
 
-  const value = getPropertyValue(rowData.parent as ContainerProperty, rowData.name, rowData.context, rowData.typeid,
-    followReferences);
+  const value = rowData.value;
 
   return (
     <Switch

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyViews/Number.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyViews/Number.tsx
@@ -3,11 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerProperty } from "@fluid-experimental/property-properties";
 import TextField, { TextFieldProps } from "@material-ui/core/TextField";
 import * as React from "react";
 import { IEditableValueCellProps, IInspectorRow } from "../InspectorTableTypes";
-import { getPropertyValue } from "../propertyInspectorUtils";
 
 type NumberProps = (IEditableValueCellProps & {
   onSubmit: (val: number, props: IEditableValueCellProps) => void;
@@ -41,8 +39,7 @@ export const NumberView: React.FunctionComponent<NumberProps> = (props) => {
     ...restProps // tslint:disable-line:trailing-comma
   } = props;
 
-  const value = getPropertyValue(rowData.parent as ContainerProperty, rowData.name, rowData.context, rowData.typeid,
-    followReferences);
+  const value = rowData.value;
 
   return (
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyViews/String.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/PropertyViews/String.tsx
@@ -3,11 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerProperty } from "@fluid-experimental/property-properties";
 import TextField, { TextFieldProps } from "@material-ui/core/TextField";
 import * as React from "react";
 import { IEditableValueCellProps } from "../InspectorTableTypes";
-import { getPropertyValue } from "../propertyInspectorUtils";
 
 type StringProps = (IEditableValueCellProps & {
   onSubmit: (val: string, props: IEditableValueCellProps) => void;
@@ -28,7 +26,6 @@ const handleKeyDown: HandleKeyDownType = (event, props) => {
 
 export const StringView: React.FunctionComponent<StringProps> = (props) => {
   const {
-    followReferences,
     TextFieldProps: textFieldProps,
     rowData,
     onBlur = (event) => { onSubmit(event.currentTarget.value, props); },
@@ -38,8 +35,7 @@ export const StringView: React.FunctionComponent<StringProps> = (props) => {
     readOnly,
   } = props;
 
-  const value = getPropertyValue(rowData.parent as ContainerProperty, rowData.name, rowData.context, rowData.typeid,
-    followReferences);
+  const value = rowData.value;
 
   return (
     <TextField

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/index.ts
@@ -37,6 +37,7 @@ export {
     IPropertyToTableRowOptions,
     IShowNextResultResult,
     SearchResult,
+    IEditableTreeRow,
 } from "./InspectorTableTypes";
 export { ModalManager, ModalContext, ModalConsumer } from "./ModalManager";
 export { ModalRoot } from "./ModalRoot";
@@ -70,3 +71,5 @@ export {
 } from "./propertyInspectorUtils";
 export { TypeColumn, useChipStyles } from "./TypeColumn";
 export { search, showNextResult } from "./utils";
+
+export { NewDataForm, INewDataFormProps } from "./NewDataForm";

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/propertyInspectorUtils.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/propertyInspectorUtils.tsx
@@ -26,8 +26,10 @@ import { InspectorMessages, minRowWidth, rowWidthInterval } from "./constants";
 import { HashCalculator } from "./HashCalculator";
 import {
   ColumnRendererType,
+  IEditableTreeRow,
   IExpandedMap, IInspectorRow, IInspectorSearchMatch,
   IPropertyToTableRowOptions,
+  isEditableTreeRow,
   IToTableRowsOptions, IToTableRowsProps, SearchResult,
 } from "./InspectorTableTypes";
 import { NameCell } from "./NameCell";
@@ -608,7 +610,10 @@ export const handleReferencePropertyEdit = async (rowData: IInspectorRow, newPat
   parentProp!.getRoot().getWorkspace()!.commit();
 };
 
-export const generateForm = (rowData: IInspectorRow, handleCreateData: any) => {
+export const generateForm = (rowData: IInspectorRow | IEditableTreeRow, handleCreateData: any) => {
+  if (isEditableTreeRow(rowData)) {
+    return true;
+  }
   if (rowData.parent!.getContext() === "array" && rowData.parent!.isPrimitiveType()) {
     handleCreateData(rowData, "", rowData.parent!.getTypeid(), "single");
     return false;

--- a/experimental/PropertyDDS/packages/property-properties/src/index.d.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/index.d.ts
@@ -2216,7 +2216,7 @@ declare module "@fluid-experimental/property-properties" {
             /**
              * Extracts typeids directly referred to in a template
              */
-            public extractDependencies(): Array<any>;
+            static extractDependencies(template: PropertyTemplateType): Array<any>;
 
             constants: any[];
 

--- a/experimental/PropertyDDS/packages/property-properties/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/index.ts
@@ -5,6 +5,7 @@
 
 import { PropertyFactory } from './propertyFactory';
 import { PropertyUtils } from './propertyUtils';
+import { PropertyTemplate } from './propertyTemplate';
 import { BaseProperty } from './properties/baseProperty';
 import { ContainerProperty } from './properties/containerProperty';
 import { MapProperty } from './properties/mapProperty';
@@ -26,6 +27,7 @@ import { enableValidations } from './enableValidations';
 export {
     PropertyFactory,
     PropertyUtils,
+    PropertyTemplate,
     BaseProperty,
     ContainerProperty,
     MapProperty,

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -364,8 +364,12 @@ export class ProxyContext implements EditableTreeContext {
             forest.applyDelta(changeFamily.intoDelta(edit));
         }, forest.anchors);
         // apply sequenced change, but now on top of the forest state before the transaction has been opened
-        changeFamily.rebaser.rebaseAnchors(this.forest.anchors, sequencedChange.change);
-        this.forest.applyDelta(changeFamily.intoDelta(sequencedChange.change));
+        // we don't use `editor.apply` here since we don't want this change to be included
+        // into our "local changes"
+        {
+            changeFamily.rebaser.rebaseAnchors(this.forest.anchors, sequencedChange.change);
+            this.forest.applyDelta(changeFamily.intoDelta(sequencedChange.change));
+        }
         // Apply local changes rebased on the new sequenced change.
         // Also, in general, sequenced changes are handled by the SharedTree, so if handled properly
         // here by the time they arrive, we don't have to track them, only to rebase

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -366,14 +366,15 @@ export class ProxyContext implements EditableTreeContext {
         // apply sequenced change, but now on top of the forest state before the transaction has been opened
         changeFamily.rebaser.rebaseAnchors(this.forest.anchors, sequencedChange.change);
         this.forest.applyDelta(changeFamily.intoDelta(sequencedChange.change));
-        // apply local changes rebased on the new sequenced change
-        for (const change of localChanges) {
-            // Also, in general, sequenced changes are handled by the SharedTree, so if handled properly
-            // here by the time they arrive, we don't have to track them, only to rebase
-            // our local changes over the most recent one.
-            const rebased = changeFamily.rebaser.rebase(change, sequencedChange);
+        // Apply local changes rebased on the new sequenced change.
+        // Also, in general, sequenced changes are handled by the SharedTree, so if handled properly
+        // here by the time they arrive, we don't have to track them, only to rebase
+        // our local changes over the most recent one.
+        localChanges.reduce((over, change, index) => {
+            const rebased = changeFamily.rebaser.rebase(change, over);
             editor.apply(rebased);
-        }
+            return tagChange(rebased, brand(index));
+        }, sequencedChange);
         this.editor = editor;
     }
 

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -21,11 +21,7 @@ export {
     replaceField,
 } from "./editableTree";
 
-export {
-    EditableTreeContext,
-    getEditableTreeContext,
-    EditableTreeIndex,
-} from "./editableTreeContext";
+export { EditableTreeContext, getEditableTreeContext } from "./editableTreeContext";
 
 export {
     PrimitiveValue,

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -19,6 +19,7 @@ export {
     getField,
     createField,
     replaceField,
+    editableTreeContextSymbol,
 } from "./editableTree";
 
 export { EditableTreeContext, getEditableTreeContext } from "./editableTreeContext";

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -21,7 +21,11 @@ export {
     replaceField,
 } from "./editableTree";
 
-export { EditableTreeContext, getEditableTreeContext } from "./editableTreeContext";
+export {
+    EditableTreeContext,
+    getEditableTreeContext,
+    EditableTreeIndex,
+} from "./editableTreeContext";
 
 export {
     PrimitiveValue,

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -39,7 +39,6 @@ export {
     MarkedArrayLike,
     isWritableArrayLike,
     isContextuallyTypedNodeDataObject,
-    EditableTreeIndex,
 } from "./editable-tree";
 export { ForestIndex } from "./forestIndex";
 export { singleMapTreeCursor, mapTreeFromCursor } from "./mapTreeCursor";

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -34,6 +34,7 @@ export {
     getField,
     createField,
     replaceField,
+    editableTreeContextSymbol,
     ContextuallyTypedNodeDataObject,
     ContextuallyTypedNodeData,
     MarkedArrayLike,

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -39,6 +39,7 @@ export {
     MarkedArrayLike,
     isWritableArrayLike,
     isContextuallyTypedNodeDataObject,
+    EditableTreeIndex,
 } from "./editable-tree";
 export { ForestIndex } from "./forestIndex";
 export { singleMapTreeCursor, mapTreeFromCursor } from "./mapTreeCursor";

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -157,6 +157,7 @@ export {
     getField,
     createField,
     replaceField,
+    editableTreeContextSymbol,
     ContextuallyTypedNodeDataObject,
     ContextuallyTypedNodeData,
     MarkedArrayLike,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -44,7 +44,6 @@ import {
     runSynchronousTransaction,
     buildForest,
     ContextuallyTypedNodeData,
-    EditableTreeIndex,
 } from "../feature-libraries";
 
 /**
@@ -130,17 +129,10 @@ class SharedTree
             defaultChangeFamily,
             anchors,
         );
-        const transactionCheckout: TransactionCheckout<DefaultEditBuilder, DefaultChangeset> = {
-            forest,
-            changeFamily: defaultChangeFamily,
-            submitEdit: (edit) => this.submitEdit(edit),
-        };
-        const context = getEditableTreeContext(forest, transactionCheckout);
         const indexes: Index<DefaultChangeset>[] = [
             new SchemaIndex(runtime, schema),
             new ForestIndex(runtime, forest),
             new EditManagerIndex(runtime, editManager),
-            new EditableTreeIndex(context),
         ];
         super(
             indexes,
@@ -155,8 +147,13 @@ class SharedTree
 
         this.forest = forest;
         this.storedSchema = new SchemaEditor(schema, (op) => this.submitLocalMessage(op));
-        this.transactionCheckout = transactionCheckout;
-        this.context = context;
+        this.transactionCheckout = {
+            forest,
+            changeFamily: this.changeFamily,
+            submitEdit: (edit) => this.submitEdit(edit),
+        };
+
+        this.context = getEditableTreeContext(forest, this.transactionCheckout, this.editManager);
     }
 
     public locate(anchor: Anchor): UpPath | undefined {

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
@@ -156,7 +156,7 @@ export const schemaTypes: Set<NamedTreeSchema> = new Set([
     addressSchema,
     mapStringSchema,
     personSchema,
-    decimalSchema,
+    // decimalSchema,
 ]);
 
 export const schemaMap: Map<TreeSchemaIdentifier, NamedTreeSchema> = new Map();


### PR DESCRIPTION
This PR contains the PoC implementation of the "property inspector" based on the new tree DDS and its EditableTree API.

The new inspector utilises the EditableTree API in a "full blown" manner operating with fields and nodes in a generic way when reading. A complete traverse of the tree could be "unchained" starting debugging from here: https://github.com/sharptrip/FluidFramework/blob/3468817520fd832909571f53682169b13579dc58/experimental/PropertyDDS/examples/property-inspector/src/newInspector.tsx#L301

In contrast, the code also uses a not yet published "contextually typed API" and "simple assignments", which allows users to change data in a more convenient way: https://github.com/sharptrip/FluidFramework/blob/3468817520fd832909571f53682169b13579dc58/experimental/PropertyDDS/examples/property-inspector/src/newInspector.tsx#L138-L149

You can check the tests in the corresponding PR to get an idea of what it's all about: https://github.com/microsoft/FluidFramework/pull/13292

### !Attention!

Transaction handling and other features from commits related to the EditableTree API are not yet available (not even as a PR).